### PR TITLE
[DRAFT FOR CARPET] Reuse immutable instances, make some functions reuse existing code, and some minor changes

### DIFF
--- a/src/main/java/carpet/script/Expression.java
+++ b/src/main/java/carpet/script/Expression.java
@@ -96,7 +96,7 @@ public class Expression
         functionalEquivalence.put(operator, function);
     }
 
-    private final Map<String, Value> constants = Map.of(
+    private static final Map<String, Value> CONSTANTS = Map.of(
             "euler", Arithmetic.euler,
             "pi", Arithmetic.PI,
             "null", Value.NULL,
@@ -106,7 +106,7 @@ public class Expression
 
     protected Value getConstantFor(String surface)
     {
-        return constants.get(surface);
+        return CONSTANTS.get(surface);
     }
 
     public List<String> getExpressionSnippet(Tokenizer.Token token)

--- a/src/main/java/carpet/script/api/WorldAccess.java
+++ b/src/main/java/carpet/script/api/WorldAccess.java
@@ -427,7 +427,7 @@ public class WorldAccess {
                 BlockPos pos = ((BlockValue) v).getPos();
                 if (pos == null)
                     throw new InternalExpressionException("Cannot fetch position of an unrealized block");
-                return ListValue.of(new NumericValue(pos.getX()), new NumericValue(pos.getY()), new NumericValue(pos.getZ()));
+                return ValueConversions.of(pos);
             }
             else if (v instanceof EntityValue)
             {
@@ -1287,7 +1287,7 @@ public class WorldAccess {
                     BlockBox box = start.setBoundingBoxFromChildren();
                     structureList.put(
                             new StringValue(NBTSerializableValue.nameFromRegistryId(Registry.STRUCTURE_FEATURE.getId(entry.getKey()))),
-                            ListValue.of(ListValue.fromTriple(box.getMinX(), box.getMinY(), box.getMinZ()), ListValue.fromTriple(box.getMaxX(), box.getMaxY(), box.getMaxZ()))
+                            ValueConversions.of(box)
                     );
                 }
                 return MapValue.wrap(structureList);

--- a/src/main/java/carpet/script/language/Sys.java
+++ b/src/main/java/carpet/script/language/Sys.java
@@ -54,8 +54,7 @@ public class Sys {
         {
             if (v instanceof NumericValue num)
             {
-                if (num.isInteger()) return new NumericValue(num.getLong());
-                return new NumericValue(num.getDouble());
+                return num;
             }
             if (v instanceof ListValue || v instanceof MapValue)
             {

--- a/src/main/java/carpet/script/value/BooleanValue.java
+++ b/src/main/java/carpet/script/value/BooleanValue.java
@@ -37,11 +37,6 @@ public class BooleanValue extends NumericValue
     }
 
     @Override
-    public Value clone() {
-        return new BooleanValue(boolValue);
-    }
-
-    @Override
     public int hashCode() {
         return Boolean.hashCode(boolValue);
     }

--- a/src/main/java/carpet/script/value/FormattedTextValue.java
+++ b/src/main/java/carpet/script/value/FormattedTextValue.java
@@ -58,12 +58,6 @@ public class FormattedTextValue extends StringValue
     }
 
     @Override
-    public Value clone()
-    {
-        return new FormattedTextValue(text);
-    }
-
-    @Override
     public String getTypeString()
     {
         return "text";

--- a/src/main/java/carpet/script/value/ListValue.java
+++ b/src/main/java/carpet/script/value/ListValue.java
@@ -79,9 +79,9 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
         return ListValue.of(new NumericValue(a), new NumericValue(b), new NumericValue(c));
     }
 
-    public static Value fromTriple(int a, int b, int c)
+    public static Value fromTriple(long a, long b, long c)
     {
-        return fromTriple((double) a, b, c);
+        return ListValue.of(new NumericValue(a), new NumericValue(b), new NumericValue(c));
     }
 
 

--- a/src/main/java/carpet/script/value/NullValue.java
+++ b/src/main/java/carpet/script/value/NullValue.java
@@ -28,17 +28,12 @@ public class NullValue extends NumericValue // TODO check nonsingleton code
         return false;
     }
 
-    @Override
-    public Value clone()
-    {
-        return new NullValue();
-    }
-    private NullValue() {super(0);}
+    private NullValue() {super(0L);}
 
     @Override
     public boolean equals(final Object o)
     {
-        return o instanceof NullValue;
+        return this == o;
     }
 
     @Override

--- a/src/main/java/carpet/script/value/NumericValue.java
+++ b/src/main/java/carpet/script/value/NumericValue.java
@@ -60,7 +60,7 @@ public class NumericValue extends Value
             if (Double.isNaN(value)) return "NaN";
             if (abs(value) < epsilon) return (signum(value) < 0)?"-0":"0"; //zero rounding fails with big decimals
             // dobules have 16 point precision, 12 is plenty to display
-            return BigDecimal.valueOf(value).round(displayRounding).stripTrailingZeros().toPlainString();
+            return BigDecimal.valueOf(value).round(displayRounding).toPlainString();
         }
         catch (NumberFormatException exc)
         {
@@ -166,7 +166,7 @@ public class NumericValue extends Value
     @Override
     public Value clone()
     {
-        return new NumericValue(value, longValue);
+        return this;
     }
 
     @Override
@@ -213,7 +213,7 @@ public class NumericValue extends Value
     public NumericValue(String value)
     {
         BigDecimal decimal = new BigDecimal(value);
-        if (decimal.stripTrailingZeros().scale() <= 0)
+        if (decimal.scale() <= 0)
         {
             try
             {
@@ -225,8 +225,7 @@ public class NumericValue extends Value
     }
     public NumericValue(long value)
     {
-        this.longValue = value;
-        this.value = (double)value;
+        this((double)value, value);
     }
 
     @Override

--- a/src/main/java/carpet/script/value/StringValue.java
+++ b/src/main/java/carpet/script/value/StringValue.java
@@ -5,7 +5,7 @@ import net.minecraft.nbt.NbtElement;
 
 public class StringValue extends Value
 {
-    public static Value EMPTY = StringValue.of("");
+    public static final Value EMPTY = StringValue.of("");
 
     private String str;
 
@@ -22,7 +22,7 @@ public class StringValue extends Value
     @Override
     public Value clone()
     {
-        return new StringValue(str);
+        return this;
     }
 
     public StringValue(String str)

--- a/src/main/java/carpet/script/value/Value.java
+++ b/src/main/java/carpet/script/value/Value.java
@@ -16,12 +16,12 @@ import java.util.stream.Collectors;
 
 public abstract class Value implements Comparable<Value>, Cloneable
 {
-    public static NumericValue FALSE = BooleanValue.FALSE;
-    public static NumericValue TRUE = BooleanValue.TRUE;
-    public static NumericValue ZERO = new NumericValue(0);
-    public static NumericValue ONE = new NumericValue(1);
+    public static final NumericValue FALSE = BooleanValue.FALSE;
+    public static final NumericValue TRUE = BooleanValue.TRUE;
+    public static final NumericValue ZERO = new NumericValue(0);
+    public static final NumericValue ONE = new NumericValue(1);
 
-    public static NullValue NULL = NullValue.NULL;
+    public static final NullValue NULL = NullValue.NULL;
 
     public String boundVariable;
 

--- a/src/main/java/carpet/script/value/ValueConversions.java
+++ b/src/main/java/carpet/script/value/ValueConversions.java
@@ -5,6 +5,8 @@ import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
 import carpet.script.exception.Throwables;
 import carpet.utils.BlockInfo;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.MapColor;
 import net.minecraft.block.pattern.CachedBlockPosition;
@@ -54,7 +56,7 @@ public class ValueConversions
 {
     public static Value of(BlockPos pos)
     {
-        return ListValue.of(new NumericValue(pos.getX()), new NumericValue(pos.getY()), new NumericValue(pos.getZ()));
+        return ListValue.fromTriple(pos.getX(), pos.getY(), pos.getZ());
     }
 
     public static Value ofOptional(BlockPos pos)
@@ -65,7 +67,7 @@ public class ValueConversions
 
     public static Value of(Vec3d vec)
     {
-        return ListValue.of(new NumericValue(vec.x), new NumericValue(vec.y), new NumericValue(vec.z));
+        return ListValue.fromTriple(vec.x, vec.y, vec.z);
     }
 
     public static Value of(ColumnPos cpos) { return ListValue.of(new NumericValue(cpos.x), new NumericValue(cpos.z));}
@@ -176,9 +178,7 @@ public class ValueConversions
     {
         if (id == null) // should be Value.NULL
             return Value.NULL;
-        if (id.getNamespace().equals("minecraft"))
-            return new StringValue(id.getPath());
-        return new StringValue(id.toString());
+        return new StringValue(simplify(id));
     }
 
     public static String simplify(Identifier id)
@@ -351,7 +351,7 @@ public class ValueConversions
     }
 
 
-    private static final Map<Integer, ListValue> slotIdsToSlotParams = new HashMap<Integer, ListValue>() {{
+    private static final Int2ObjectMap<ListValue> slotIdsToSlotParams = new Int2ObjectOpenHashMap<ListValue>() {{
         int n;
         //covers blocks, player hotbar and inventory, and all default inventories
         for(n = 0; n < 54; ++n) {
@@ -391,7 +391,7 @@ public class ValueConversions
     public static Value ofVanillaSlotResult(int itemSlot)
     {
         Value ret = slotIdsToSlotParams.get(itemSlot);
-        if (ret == null) return ListValue.of(Value.NULL, NumericValue.of(itemSlot));
+        if (ret == null) return ListValue.of(Value.NULL, new NumericValue(itemSlot));
         return ret;
     }
 


### PR DESCRIPTION
All minor changes:

- Makes NumericValue, StringValue and subclasses return themselves on clone. At the end of the day, all they did was make an instance with the same thing inside. I just thought why have those duped instances. This also changes NullValue.equals() to be reference equality
- ~Makes some code (around ValueConversions) reuse existing methods~
    - ~of(Identifier) now uses simplify()~
    - ~Moves some duped code to call ValueConversions~
    - Makes of(BlockPos) and of(Vec3d) call ListValue.fromTriple
    - Makes ListValue.fromTriple(int) accept longs instead and use long-specific NumericValue constructor
- ~Makes slot id to lv map be int specific~
- Makes constants map static so each expression doesn't hold a copy
- Makes Value.NULL, Value.TRUE, etc constants final