### PR TITLE
Don't add `Mod` to CF release to prevent cutting game version

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -103,7 +103,7 @@ jobs:
           file_path: build/libs/${{ steps.findjar.outputs.jarname }}
           changelog_type: markdown
           changelog: ${{ github.event.release.body }}
-          display_name: Carpet Mod v${{ needs.Get-Properties.outputs.carpet-version }} for ${{ steps.getbranchinfo.outputs.version }}
+          display_name: Carpet v${{ needs.Get-Properties.outputs.carpet-version }} for ${{ steps.getbranchinfo.outputs.version }}
           game_versions: 7499,4458,${{ steps.getbranchinfo.outputs.curse-versions }} #Fabric,Java 8,[version (s) for the branch]
           release_type: ${{ needs.Get-Properties.outputs.release-type }}
       - name: Ask Gradle to publish


### PR DESCRIPTION
Multiple people have reported crashes because this is what CurseForge shows for the latest versions for snapshots:
![imagen](https://user-images.githubusercontent.com/17107132/180880763-31f2b321-c0d0-4610-a37e-05c35296bfa1.png)

It was just that they were trying to run it on 1.19.

This removes the `Mod` from there so more stuff fits and hopefully helps people not get lost.